### PR TITLE
220 allow users to sign in to different account

### DIFF
--- a/actions/auth/auth.ts
+++ b/actions/auth/auth.ts
@@ -1,8 +1,8 @@
-// app/actions/auth.ts
 'use server';
 
-import { User_Info } from '@/types/users';
+import { User, User_Info } from '@/types/users';
 import { cookies } from 'next/headers';
+import { decodeToken } from '@/lib/utils';
 
 export async function setAuthCookie(userData: User_Info) {
   const cookieStore = await cookies();
@@ -33,6 +33,55 @@ export async function setAuthCookie(userData: User_Info) {
     path: '/',
     sameSite: 'lax',
   });
+}
+
+export async function googleAuthCallback(token: string) {
+  const decoded = decodeToken(token) as User;
+  if (!decoded?.accounts) return { success: false };
+
+  if (decoded.accounts.length === 1) {
+    const account = decoded.accounts[0];
+    await setAuthCookie({
+      userId: decoded.sub ?? null,
+      userName: decoded.email ?? null,
+      accountId: account.id,
+      roleId: account.role?.id ?? null,
+      role: account.role?.name ?? null,
+      imageUrl: decoded.imageUrl ?? null,
+      token: token,
+    });
+    return { success: true, requiresSelection: false };
+  }
+
+  return {
+    success: true,
+    requiresSelection: true,
+    accounts: decoded.accounts.map(acc => ({
+      id: acc.id,
+      name: acc.name,
+      role: acc.role?.name ?? null,
+    })),
+  };
+}
+
+export async function selectAccount(token: string, accountId: string) {
+  const decoded = decodeToken(token) as User;
+  if (!decoded?.accounts) return { success: false };
+
+  const account = decoded.accounts.find(acc => acc.id === accountId);
+  if (!account) return { success: false };
+
+  await setAuthCookie({
+    userId: decoded.sub ?? null,
+    userName: decoded.email ?? null,
+    accountId: account.id,
+    roleId: account.role?.id ?? null,
+    role: account.role?.name ?? null,
+    imageUrl: decoded.imageUrl ?? null,
+    token: token,
+  });
+
+  return { success: true };
 }
 
 export async function removeUserProfile() {

--- a/actions/auth/auth.ts
+++ b/actions/auth/auth.ts
@@ -56,7 +56,7 @@ export async function googleAuthCallback(token: string) {
   return {
     success: true,
     requiresSelection: true,
-    accounts: decoded.accounts.map(acc => ({
+    accounts: decoded.accounts.map((acc) => ({
       id: acc.id,
       name: acc.name,
       role: acc.role?.name ?? null,
@@ -68,7 +68,7 @@ export async function selectAccount(token: string, accountId: string) {
   const decoded = decodeToken(token) as User;
   if (!decoded?.accounts) return { success: false };
 
-  const account = decoded.accounts.find(acc => acc.id === accountId);
+  const account = decoded.accounts.find((acc) => acc.id === accountId);
   if (!account) return { success: false };
 
   await setAuthCookie({

--- a/actions/auth/login.ts
+++ b/actions/auth/login.ts
@@ -10,7 +10,7 @@ const Url = {
   login: `${BASE_URL}/auth/google`,
 };
 
-export const googleAuthCallback = async () => {
+export const googleAuthCallbackk = async () => {
   redirect(process.env.GOOGLE_CALLBACK_URL ?? '/');
 };
 export const apiUrl = async () => {

--- a/components/login-page/login-page-card.tsx
+++ b/components/login-page/login-page-card.tsx
@@ -7,36 +7,65 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { redirect, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { decodeToken } from '@/lib/utils';
-import { User } from '@/types/users';
+import { User, Account, User_Info } from '@/types/users';
 import { setAuthCookie } from '@/actions/auth/auth';
 import { googleAuthCallback } from '@/actions/auth/login';
 
 const LoginPageCard = () => {
   const searchParams = useSearchParams();
-  useEffect(() => {
-    const token = searchParams.get('token'); // Extract the token from the URL
-    if (token) {
-      const decoded = decodeToken(token); // Ensure decodeToken is working properly
-      const userInfo = decoded as User;
+  const router = useRouter();
+  const [userInfo, setUserInfo] = useState<User | null>(null);
+const [loginToken, setLoginToken] = useState<string | null>(null);
 
-      // Fix: Correctly access the first account
-      const user = {
-        userId: userInfo?.sub ?? null,
-        userName: userInfo?.email ?? 'Guest', // Default to "Guest" if no name
-        accountId: userInfo?.accounts?.[0]?.id ?? null, // Ensure we access index 0
-        roleId: userInfo?.accounts?.[0]?.role?.id ?? null, // Access role correctly
-        role: userInfo?.accounts?.[0]?.role?.name ?? null,
-        imageUrl: userInfo?.imageUrl ?? null,
+
+useEffect(() => {
+  const token = searchParams.get('token');
+  if (token) {
+    const decoded = decodeToken(token) as User;
+    if (!decoded?.accounts || decoded.accounts.length === 0) return;
+
+    if (decoded.accounts.length === 1) {
+      const singleUser: User_Info = {
+        userId: decoded.sub ?? null,
+        userName: decoded.email ?? null,
+        accountId: decoded.accounts[0].id,
+        roleId: decoded.accounts[0].role?.id ?? null,
+        role: decoded.accounts[0].role?.name ?? null,
+        imageUrl: decoded.imageUrl ?? null,
         token,
       };
-
-      setAuthCookie(user);
-      // Fix: Store user properly in localStorage
+      setAuthCookie(singleUser);
+      router.refresh();
+    } else {
+      setUserInfo(decoded); 
+      setLoginToken(token); 
     }
-  }, [searchParams]);
+  }
+}, [searchParams]);
+
+
+const handleAccountSelect = (account: Account) => {
+  if (!userInfo || !loginToken) return;
+
+  const user: User_Info = {
+    userId: userInfo.sub ?? null,
+    userName: userInfo.email ?? null,
+    accountId: account.id,
+    roleId: account.role?.id ?? null,
+    role: account.role?.name ?? null,
+    imageUrl: userInfo.imageUrl ?? null,
+    token: loginToken,
+  };
+
+  setAuthCookie(user);
+  router.refresh();
+};
+
+  
+
   const handleLogin = () => {
     googleAuthCallback();
   };
@@ -52,13 +81,29 @@ const LoginPageCard = () => {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4 pt-0">
-        <Button
-          className="w-96 h-10 font-medium text-sm"
-          variant="default"
-          onClick={handleLogin}
-        >
-          Login with Google
-        </Button>
+        {!userInfo ? (
+          <Button
+            className="w-96 h-10 font-medium text-sm"
+            variant="default"
+            onClick={handleLogin}
+          >
+            Login with Google
+          </Button>
+        ) : (
+          <>
+            <p className="text-center">Choose an account to continue</p>
+            {userInfo.accounts?.map((acc) => (
+              <Button
+                key={acc.id}
+                className="w-96 h-10"
+                variant="secondary"
+                onClick={() => handleAccountSelect(acc)}
+              >
+                {acc.name} — {acc.role?.name}
+              </Button>
+            ))}
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/login-page/login-page-card.tsx
+++ b/components/login-page/login-page-card.tsx
@@ -18,53 +18,49 @@ const LoginPageCard = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [userInfo, setUserInfo] = useState<User | null>(null);
-const [loginToken, setLoginToken] = useState<string | null>(null);
+  const [loginToken, setLoginToken] = useState<string | null>(null);
 
+  useEffect(() => {
+    const token = searchParams.get('token');
+    if (token) {
+      const decoded = decodeToken(token) as User;
+      if (!decoded?.accounts || decoded.accounts.length === 0) return;
 
-useEffect(() => {
-  const token = searchParams.get('token');
-  if (token) {
-    const decoded = decodeToken(token) as User;
-    if (!decoded?.accounts || decoded.accounts.length === 0) return;
-
-    if (decoded.accounts.length === 1) {
-      const singleUser: User_Info = {
-        userId: decoded.sub ?? null,
-        userName: decoded.email ?? null,
-        accountId: decoded.accounts[0].id,
-        roleId: decoded.accounts[0].role?.id ?? null,
-        role: decoded.accounts[0].role?.name ?? null,
-        imageUrl: decoded.imageUrl ?? null,
-        token,
-      };
-      setAuthCookie(singleUser);
-      router.refresh();
-    } else {
-      setUserInfo(decoded); 
-      setLoginToken(token); 
+      if (decoded.accounts.length === 1) {
+        const singleUser: User_Info = {
+          userId: decoded.sub ?? null,
+          userName: decoded.email ?? null,
+          accountId: decoded.accounts[0].id,
+          roleId: decoded.accounts[0].role?.id ?? null,
+          role: decoded.accounts[0].role?.name ?? null,
+          imageUrl: decoded.imageUrl ?? null,
+          token,
+        };
+        setAuthCookie(singleUser);
+        router.refresh();
+      } else {
+        setUserInfo(decoded);
+        setLoginToken(token);
+      }
     }
-  }
-}, [searchParams]);
+  }, [searchParams]);
 
+  const handleAccountSelect = (account: Account) => {
+    if (!userInfo || !loginToken) return;
 
-const handleAccountSelect = (account: Account) => {
-  if (!userInfo || !loginToken) return;
+    const user: User_Info = {
+      userId: userInfo.sub ?? null,
+      userName: userInfo.email ?? null,
+      accountId: account.id,
+      roleId: account.role?.id ?? null,
+      role: account.role?.name ?? null,
+      imageUrl: userInfo.imageUrl ?? null,
+      token: loginToken,
+    };
 
-  const user: User_Info = {
-    userId: userInfo.sub ?? null,
-    userName: userInfo.email ?? null,
-    accountId: account.id,
-    roleId: account.role?.id ?? null,
-    role: account.role?.name ?? null,
-    imageUrl: userInfo.imageUrl ?? null,
-    token: loginToken,
+    setAuthCookie(user);
+    router.refresh();
   };
-
-  setAuthCookie(user);
-  router.refresh();
-};
-
-  
 
   const handleLogin = () => {
     googleAuthCallback();

--- a/components/login-page/login-page-card.tsx
+++ b/components/login-page/login-page-card.tsx
@@ -9,61 +9,47 @@ import {
 } from '@/components/ui/card';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { decodeToken } from '@/lib/utils';
-import { User, Account, User_Info } from '@/types/users';
-import { setAuthCookie } from '@/actions/auth/auth';
-import { googleAuthCallback } from '@/actions/auth/login';
+import { googleAuthCallback, selectAccount } from '@/actions/auth/auth';
+import { googleAuthCallbackk } from '@/actions/auth/login';
+import type { AccountInfo } from '@/types/users';
 
 const LoginPageCard = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const [userInfo, setUserInfo] = useState<User | null>(null);
-  const [loginToken, setLoginToken] = useState<string | null>(null);
+  const [accounts, setAccounts] = useState<AccountInfo[]>([]);
+  const [authToken, setAuthToken] = useState<string | null>(null);
 
   useEffect(() => {
     const token = searchParams.get('token');
-    if (token) {
-      const decoded = decodeToken(token) as User;
-      if (!decoded?.accounts || decoded.accounts.length === 0) return;
+    if (!token) return;
 
-      if (decoded.accounts.length === 1) {
-        const singleUser: User_Info = {
-          userId: decoded.sub ?? null,
-          userName: decoded.email ?? null,
-          accountId: decoded.accounts[0].id,
-          roleId: decoded.accounts[0].role?.id ?? null,
-          role: decoded.accounts[0].role?.name ?? null,
-          imageUrl: decoded.imageUrl ?? null,
-          token,
-        };
-        setAuthCookie(singleUser);
-        router.refresh();
-      } else {
-        setUserInfo(decoded);
-        setLoginToken(token);
+    const handleToken = async () => {
+      const result = await googleAuthCallback(token);
+
+      if (result.success) {
+        if (result.requiresSelection && result.accounts) {
+          setAccounts(result.accounts as AccountInfo[]);
+          setAuthToken(token);
+        } else {
+          router.refresh();
+        }
       }
-    }
-  }, [searchParams]);
-
-  const handleAccountSelect = (account: Account) => {
-    if (!userInfo || !loginToken) return;
-
-    const user: User_Info = {
-      userId: userInfo.sub ?? null,
-      userName: userInfo.email ?? null,
-      accountId: account.id,
-      roleId: account.role?.id ?? null,
-      role: account.role?.name ?? null,
-      imageUrl: userInfo.imageUrl ?? null,
-      token: loginToken,
     };
 
-    setAuthCookie(user);
-    router.refresh();
+    handleToken();
+  }, [searchParams]);
+
+  const handleAccountSelect = async (accountId: string) => {
+    if (!authToken) return;
+
+    const result = await selectAccount(authToken, accountId);
+    if (result.success) {
+      router.refresh();
+    }
   };
 
   const handleLogin = () => {
-    googleAuthCallback();
+    googleAuthCallbackk();
   };
 
   return (
@@ -77,7 +63,7 @@ const LoginPageCard = () => {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4 pt-0">
-        {!userInfo ? (
+        {accounts.length === 0 ? (
           <Button
             className="w-96 h-10 font-medium text-sm"
             variant="default"
@@ -88,14 +74,14 @@ const LoginPageCard = () => {
         ) : (
           <>
             <p className="text-center">Choose an account to continue</p>
-            {userInfo.accounts?.map((acc) => (
+            {accounts.map((acc) => (
               <Button
                 key={acc.id}
                 className="w-96 h-10"
                 variant="secondary"
-                onClick={() => handleAccountSelect(acc)}
+                onClick={() => handleAccountSelect(acc.id)}
               >
-                {acc.name} — {acc.role?.name}
+                {acc.name} — {acc.role ?? ''}
               </Button>
             ))}
           </>

--- a/types/users.ts
+++ b/types/users.ts
@@ -15,16 +15,18 @@ export interface User {
   accounts?: Account[];
   sub?: string;
 }
+
 export type Account = {
   id: string;
   name: string;
-  role?: role;
+  role?: Role;
   imageUrl?: string;
   lastUpdated?: string;
   userId?: string;
   email?: string;
 };
-export type role = {
+
+export type Role = {
   id: string;
   name: string;
 };
@@ -37,6 +39,12 @@ export type User_Info = {
   token?: string | null;
   imageUrl?: string | null;
   userId?: string | null;
+};
+
+export type AccountInfo = {
+  id: string;
+  name: string;
+  role: string | null;
 };
 
 export type SortField = 'name' | 'email' | 'joinedDate' | 'location';


### PR DESCRIPTION
![Screenshot 2025-04-14 061212](https://github.com/user-attachments/assets/2ce478d6-6d16-4f21-b370-e4253f21a018)

I add account selection UI for multi-account users during login
- Decode token after Google login and check for multiple accounts
- Show UI to let user choose account if more than one exists
- Set selected account info in auth cookies
- Ensure types are respected using User_Info and separate login token state
- Auto-select account if only one is present
